### PR TITLE
Fix typo in OrderDetails

### DIFF
--- a/src/components/organisms/OrderDefails/OrderDetails.tsx
+++ b/src/components/organisms/OrderDefails/OrderDetails.tsx
@@ -38,7 +38,7 @@ const OrderDetails = ({ order, showStatus }: OrderDetailsProps) => {
               Payment status:{" "}
               <span
                 className="text-ui-fg-subtle "
-                sata-testid="order-payment-status"
+                data-testid="order-payment-status"
               >
                 {/* {formatStatus(order.payment_status)} */}
               </span>


### PR DESCRIPTION
## Summary
- fix typo in `data-testid` attribute in OrderDetails

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebedb9870832aa08741030a682083