### PR TITLE
Adjust error state type in RegisterForm

### DIFF
--- a/src/components/molecules/RegisterForm/RegisterForm.tsx
+++ b/src/components/molecules/RegisterForm/RegisterForm.tsx
@@ -36,7 +36,7 @@ export const RegisterForm = () => {
 }
 
 const Form = () => {
-  const [error, setError] = useState()
+  const [error, setError] = useState<string | null>(null)
   const {
     handleSubmit,
     register,


### PR DESCRIPTION
## Summary
- type the error state in `RegisterForm` as `string | null`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ebeecc504832a93e42fad8e8ca647